### PR TITLE
refactor: 가사 관리 로직을 PlayingInfoProvider로 분리함

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
       }
     ],
     'import/prefer-default-export': 'off',
+    'solid/style-prop': ['error', { allowString: true }],
     'camelcase': ['error', { properties: 'never' }],
     'class-methods-use-this': 'off',
     'lines-around-comment': [
@@ -44,7 +45,6 @@ module.exports = {
       },
     ],
     'max-len': 'off',
-    // 'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-mixed-operators': 'error',
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],
     'no-tabs': 'error',
@@ -53,7 +53,7 @@ module.exports = {
       avoidEscape: true,
       allowTemplateLiterals: false,
     }],
-    'quote-props': ['error', 'consistent']
+    'quote-props': ['error', 'consistent'],
   },
   ignorePatterns: ['dist', 'node_modules'],
 };

--- a/extensions/alspotron.js
+++ b/extensions/alspotron.js
@@ -32,7 +32,7 @@
   const getInfo = async () => {
     if (!Spicetify.Player.isPlaying()) {
       return {
-        playing: false
+        status: 'stopped',
       };
     }
 

--- a/renderer/lyrics/SideBar.tsx
+++ b/renderer/lyrics/SideBar.tsx
@@ -56,6 +56,9 @@ const SideBar = () => {
           <path d="M8.293 4.293a1 1 0 0 0 0 1.414L14.586 12l-6.293 6.293a1 1 0 1 0 1.414 1.414l7-7a1 1 0 0 0 0-1.414l-7-7a1 1 0 0 0-1.414 0Z" fill="#ffffff"/>
         </svg>
       </Card>
+      <div class={'flex-1 block text-center overflow-scroll whitespace-pre-line'}>
+        {lyricItems()}
+      </div>
     </div>
   )
 };

--- a/renderer/main/App.tsx
+++ b/renderer/main/App.tsx
@@ -1,149 +1,34 @@
-import alsong from 'alsong';
-import { For, createEffect, createMemo, createSignal, on } from 'solid-js';
-import { TransitionGroup } from 'solid-transition-group';
-
-import TreeMap from 'ts-treemap';
-import IconMusic from '../../assets/icon_music.png';
 import useConfig from '../hooks/useConfig';
-import useLyricMapper from '../hooks/useLyricMapper';
-import { UpdateData } from '../types';
+import AnchoredView from './components/AnchoredView';
 import LyricProgressBar from './components/LyricProgressBar';
-import LyricsItem from './components/LyricsItem';
-
-type Lyric = Awaited<ReturnType<typeof alsong.getLyricById>>;
+import Lyrics from './components/Lyrics';
+import PlayingInfoProvider from './components/PlayingInfoProvider';
 
 const App = () => {
-  const [progress, setProgress] = createSignal(0);
-  const [duration, setDuration] = createSignal(0);
-  const [title, setTitle] = createSignal('Not Playing');
-  const [artist, setArtist] = createSignal('N/A');
-  const [status, setStatus] = createSignal('idle');
-  const [coverUrl, setCoverUrl] = createSignal<string>();
-  const [lyrics, setLyrics] = createSignal<TreeMap<number, string[]> | null>(null);
-  const [originalData, setOriginalData] = createSignal<UpdateData | null>(null);
-
-  const [lyricMapper] = useLyricMapper();
   const [config] = useConfig();
 
-  const lyricIndex = createMemo(() => {
-    if (lyrics() === null) return 0;
-
-    return lyrics().lowerKey(progress() + 1225);
-  });
-
-  window.ipcRenderer.on('update', (_, message: { data: UpdateData }) => {
-    const data: UpdateData = message.data;
-
-    setOriginalData(data);
-
-    setStatus(data.status);
-    setTitle(data.title);
-    setArtist(data.artists.join(', '));
-    setProgress(data.progress);
-    setDuration(data.duration);
-    setCoverUrl(
-      data.cover_url.match(/^(?:file|https?):\/\//) ? data.cover_url : IconMusic,
-    );
-  });
-
-  createEffect(on([title, coverUrl, lyricMapper], async () => {
-    const data = originalData();
-    const mapper = lyricMapper();
-
-    if (!data) return;
-    const id: number | undefined = mapper[`${data.title}:${data.cover_url}`];
-
-    const lyric = (
-      typeof id === 'number'
-        ? (await window.ipcRenderer.invoke('get-lyric-by-id', id) as Lyric ?? data)
-        : await window.ipcRenderer.invoke('get-lyric', data) as Lyric
-    )
-
-    if (lyric?.lyric) {
-      const treeMap = new TreeMap<number, string[]>();
-      for (const key in lyric.lyric) {
-        treeMap.set(~~key, lyric.lyric[key]);
-      }
-      setLyrics(treeMap);
-    }
-    else setLyrics(null);
-  }));
-
   return (
-    <div
-      class={`
-        fixed w-full h-fit
-        flex gap-4
-      `}
-      classList={{
-        'top-0': config()?.windowPosition.anchor.includes('top'),
-        'bottom-0': config()?.windowPosition.anchor.includes('bottom'),
-        'left-0': config()?.windowPosition.anchor.includes('left'),
-        'right-0': config()?.windowPosition.anchor.includes('right'),
-        'left-[50%] right-[50%] translate-x-[-50%]': ['top', 'bottom', 'center'].includes(config()?.windowPosition.anchor),
-        'top-[50%] bottom-[50%] translate-y-[-50%]': ['left', 'right', 'center'].includes(config()?.windowPosition.anchor),
-
-        'justify-start': config()?.windowPosition.anchor.includes('top'),
-        'justify-center': ['left', 'right', 'center'].includes(config()?.windowPosition.anchor),
-        'justify-end': config()?.windowPosition.anchor.includes('bottom'),
-        'items-start': config()?.windowPosition.anchor.includes('left'),
-        'items-center': ['top', 'bottom', 'center'].includes(config()?.windowPosition.anchor),
-        'items-end': config()?.windowPosition.anchor.includes('right'),
-      }}
-      style={{
-        'flex-direction': config()?.windowPosition.anchor.includes('bottom') ? 'column' : 'column-reverse',
-      }}
-    >
-      <TransitionGroup name={'lyric'}>
-        <For each={lyrics()?.get(lyricIndex()) ?? []}>
-          {(item, index) => (
-            <LyricsItem
-              status={status()}
-              delay={index()}
-              style={`
-                font-family: ${config()?.style.font};
-                font-weight: ${config()?.style.fontWeight};
-                font-size: ${
-                  typeof config()?.style.lyric.fontSize === 'string'
-                    ? config()?.style.lyric.fontSize
-                    : `${config()?.style.lyric.fontSize}px`
-                };
-                color: ${config()?.style.lyric.color};
-                background-color: ${config()?.style.lyric.background};
-              `}
-            >
-              {item}
-            </LyricsItem>
-          )}
-        </For>
-      </TransitionGroup>
-      <div />
-      <LyricProgressBar
-        coverUrl={coverUrl()}
-        title={title()}
-        artist={artist()}
-        percent={progress() / duration()}
-        status={status()}
-        style={`
-          max-width: ${config()?.style.nowPlaying.maxWidth}px;
-          font-family: ${config()?.style.font};
-          font-weight: ${config()?.style.fontWeight};
-          color: ${config()?.style.nowPlaying.color};
-          background-color: ${config()?.style.nowPlaying.background};
-        `}
-        textStyle={`
-          font-size: ${
-            typeof config()?.style.nowPlaying.fontSize === 'string'
-              ? config()?.style.nowPlaying.fontSize
-              : `${config()?.style.nowPlaying.fontSize}px`
-          };
-        `}
-        progressStyle={`
-          background-color: ${config()?.style.nowPlaying.backgroundProgress};
-        `}
-      />
-    </div>
-  )
+    <PlayingInfoProvider>
+      <AnchoredView>
+        <Lyrics />
+        <LyricProgressBar
+          style={`
+            max-width: ${config()?.style.nowPlaying.maxWidth}px;
+            font-family: ${config()?.style.font};
+            font-weight: ${config()?.style.fontWeight};
+            color: ${config()?.style.nowPlaying.color};
+            background-color: ${config()?.style.nowPlaying.background};
+          `}
+          textStyle={`
+            font-size: ${config()?.style.nowPlaying.fontSize}px;
+          `}
+          progressStyle={`
+            background-color: ${config()?.style.nowPlaying.backgroundProgress};
+          `}
+        />
+      </AnchoredView>
+    </PlayingInfoProvider>
+  );
 };
 
 export default App;

--- a/renderer/main/components/AnchoredView.tsx
+++ b/renderer/main/components/AnchoredView.tsx
@@ -1,0 +1,34 @@
+import {JSX} from 'solid-js';
+import useConfig from '../../hooks/useConfig';
+
+const AnchoredView = (props: { children: JSX.Element }) => {
+  const [config] = useConfig();
+  return (
+      <div
+        class="fixed w-full h-fit flex gap-4"
+        classList={{
+          'top-0': config()?.windowPosition.anchor.includes('top'),
+          'bottom-0': config()?.windowPosition.anchor.includes('bottom'),
+          'left-0': config()?.windowPosition.anchor.includes('left'),
+          'right-0': config()?.windowPosition.anchor.includes('right'),
+          'left-[50%] right-[50%] translate-x-[-50%]': ['top', 'bottom', 'center'].includes(config()?.windowPosition.anchor),
+          'top-[50%] bottom-[50%] translate-y-[-50%]': ['left', 'right', 'center'].includes(config()?.windowPosition.anchor),
+
+          'justify-start': config()?.windowPosition.anchor.includes('top'),
+          'justify-center': ['left', 'right', 'center'].includes(config()?.windowPosition.anchor),
+          'justify-end': config()?.windowPosition.anchor.includes('bottom'),
+          'items-start': config()?.windowPosition.anchor.includes('left'),
+          'items-center': ['top', 'bottom', 'center'].includes(config()?.windowPosition.anchor),
+          'items-end': config()?.windowPosition.anchor.includes('right'),
+        }}
+        style={{
+          '--text-align': config()?.windowPosition.anchor.match(/left|right|center/)?.at(0) ?? 'center',
+          'flex-direction': config()?.windowPosition.anchor.includes('bottom') ? 'column' : 'column-reverse',
+        }}
+      >
+      {props.children}
+    </div>
+  );
+};
+
+export default AnchoredView;

--- a/renderer/main/components/LyricProgressBar.tsx
+++ b/renderer/main/components/LyricProgressBar.tsx
@@ -1,16 +1,13 @@
 import { splitProps } from 'solid-js';
-// eslint-disable-next-line import/no-unresolved
-import { JSX } from 'solid-js/jsx-runtime';
 import icon from '../../../assets/icon_music.png';
 import Marquee from '../../components/Marquee';
 import { cx } from '../../utils/classNames';
+import { usePlayingInfo } from './PlayingInfoProvider';
+import type { JSX } from 'solid-js/jsx-runtime';
 
 interface LyricProgressBarProps extends JSX.HTMLAttributes<HTMLDivElement> {
-  percent: number;
-  title: string;
-  artist: string;
-  status?: string;
-  coverUrl?: string;
+  style?: string;
+  class?: string;
 
   progressStyle?: string;
   progressClass?: string;
@@ -20,43 +17,45 @@ interface LyricProgressBarProps extends JSX.HTMLAttributes<HTMLDivElement> {
 }
 
 const LyricProgressBar = (props: LyricProgressBarProps) => {
-  const [local, style, leftProps] = splitProps(
+  const { coverUrl, title, artist, progress, duration, status } = usePlayingInfo();
+  const [style, containerProps] = splitProps(
     props,
-    ['percent', 'title', 'artist', 'status', 'coverUrl'],
-    ['progressClass', 'progressStyle', 'textClass', 'textStyle'],
+    ['class', 'style', 'progressClass', 'progressStyle', 'textClass', 'textStyle'],
   );
 
   return (
     <div
-      {...leftProps}
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      style={`--percent: ${local.percent * 100}%; opacity: ${local.status === 'stopped' ? 0.5 : 1}; ${leftProps.style}`}
+      style={`
+        --percent: ${progress() / duration() * 100}%;
+        opacity: ${status() === 'stopped' ? 0.5 : 1};
+        ${style.style}
+      `}
       class={cx(
         `
           relative p-3 transition-all duration-[225ms] ease-out z-0
           bg-gray-900/50 text-gray-50 rounded-md overflow-hidden
         `,
-        leftProps.class,
+        style.class,
       )}
+      {...containerProps}
     >
       <div
         class={cx(
-          'absolute inset-0 bg-gray-500 z-[-1] scale-x-[--percent] origin-left transition-all duration-225 ease-[cubic-bezier(0.34, 1.56, 0.64, 1)]',
+          `
+            absolute inset-0 bg-gray-500 z-[-1] scale-x-[--percent] origin-left
+            transition-all duration-225 ease-[cubic-bezier(0.34, 1.56, 0.64, 1)]
+          `,
           style.progressClass,
         )}
         style={style.progressStyle}
       />
-      <div
-        class={`
-          flex flex-row justify-start items-center gap-2 z-20
-        `}
-      >
+      <div class={'flex flex-row justify-start items-center gap-2 z-20'}>
         <img
-          src={local.coverUrl ?? icon}
+          src={coverUrl() ?? icon}
           class={`
             w-6 h-6 object-contain transition-all duration-[225ms] ease-out
-            ${local.status === 'stopped' ? 'grayscale' : ''}
-            ${local.status === 'stopped' ? 'scale-95' : ''}
+            ${status() === 'stopped' ? 'grayscale' : ''}
+            ${status() === 'stopped' ? 'scale-95' : ''}
           `}
         />
         <Marquee gap={32}>
@@ -64,11 +63,7 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
             class={cx('w-fit flex flex-row justify-start items-center gap-2', style.textClass)}
             style={style.textStyle}
           >
-            {local.artist}
-            {' '}
-            -
-            {' '}
-            {local.title}
+            {`${artist()} - ${title()}`}
           </div>
         </Marquee>
       </div>

--- a/renderer/main/components/Lyrics.tsx
+++ b/renderer/main/components/Lyrics.tsx
@@ -1,0 +1,41 @@
+import { createMemo, For } from 'solid-js';
+import { TransitionGroup } from 'solid-transition-group'
+import useConfig from '../../hooks/useConfig';
+import LyricsItem from './LyricsItem'
+import { usePlayingInfo } from './PlayingInfoProvider';
+
+const TRANSITION_DURATION = 1225;
+
+const Lyrics = () => {
+  const [config] = useConfig();
+  const { status, lyrics, progress } = usePlayingInfo();
+  const lyric = createMemo(() => {
+    if (lyrics() === null) return lyrics()?.get(0);
+    return lyrics().lowerEntry(progress() + TRANSITION_DURATION)?.[1];
+  });
+
+  return (
+      <TransitionGroup name={'lyric'}>
+        <For each={lyric() ?? []}>
+          {(item, index) => item && (
+            <LyricsItem
+              status={status()}
+              delay={index()}
+              style={`
+                font-family: ${config()?.style.font};
+                font-weight: ${config()?.style.fontWeight};
+                font-size: ${config()?.style.lyric.fontSize}px;
+                color: ${config()?.style.lyric.color};
+                background-color: ${config()?.style.lyric.background};
+                text-align: var(--text-align);
+              `}
+            >
+              {item}
+            </LyricsItem>
+          )}
+        </For>
+      </TransitionGroup>
+    );
+};
+
+export default Lyrics;

--- a/renderer/main/components/PlayingInfoProvider.tsx
+++ b/renderer/main/components/PlayingInfoProvider.tsx
@@ -41,10 +41,6 @@ const PlayingInfoProvider = (props: { children: JSX.Element }) => {
 
     setOriginalData(data);
     setStatus(data.status);
-    if (!data.status && data.playing === false) {
-      // for Spotify
-      setStatus('stopped');
-    }
 
     if (typeof data.title === 'string') {
       setTitle(data.title);

--- a/renderer/main/components/PlayingInfoProvider.tsx
+++ b/renderer/main/components/PlayingInfoProvider.tsx
@@ -79,7 +79,6 @@ const PlayingInfoProvider = (props: { children: JSX.Element }) => {
     if (!data) return;
 
     const id: number | undefined = mapper[`${data.title}:${data.cover_url}`];
-    console.log(id);
     const lyricInfo = await (async () => {
       const alsongLyric = (
         typeof id === 'number'
@@ -87,7 +86,6 @@ const PlayingInfoProvider = (props: { children: JSX.Element }) => {
           : await window.ipcRenderer.invoke('get-lyric', data) as Lyric
       );
 
-    console.log(alsongLyric);
       if (alsongLyric) {
         return { kind: 'alsong', data: alsongLyric } as const;
       }

--- a/renderer/main/components/PlayingInfoProvider.tsx
+++ b/renderer/main/components/PlayingInfoProvider.tsx
@@ -1,0 +1,135 @@
+import alsong from 'alsong';
+import { Accessor, createContext, createEffect, createSignal, JSX, on, onCleanup, onMount, useContext } from 'solid-js';
+import TreeMap from 'ts-treemap';
+import IconMusic from '../../../assets/icon_music.png';
+import useLyricMapper from '../../hooks/useLyricMapper';
+import { UpdateData } from '../../types';
+
+type Lyric = Awaited<ReturnType<typeof alsong.getLyricById>>;
+type PlayingInfo = {
+  progress: Accessor<number>;
+  duration: Accessor<number>;
+  title: Accessor<string>;
+  artist: Accessor<string>;
+  status: Accessor<'idle' | 'playing' | 'stopped'>;
+  coverUrl: Accessor<string>;
+  lyrics: Accessor<TreeMap<number, string[]> | null>;
+  originalData: Accessor<UpdateData | null>;
+  originalLyric: Accessor<LyricInfo | null>;
+};
+
+type LyricInfo =
+  | { kind: 'alsong', data: Lyric }
+  | { kind: 'default', data: UpdateData };
+
+const PlayingInfoContext = createContext<PlayingInfo>();
+const PlayingInfoProvider = (props: { children: JSX.Element }) => {
+  const [progress, setProgress] = createSignal(0);
+  const [duration, setDuration] = createSignal(0);
+  const [title, setTitle] = createSignal('Not Playing');
+  const [artist, setArtist] = createSignal('N/A');
+  const [status, setStatus] = createSignal('idle');
+  const [coverUrl, setCoverUrl] = createSignal<string>();
+  const [lyrics, setLyrics] = createSignal<TreeMap<number, string[]> | null>(null);
+  const [originalData, setOriginalData] = createSignal<UpdateData | null>(null);
+  const [originalLyric, setOriginalLyric] = createSignal<LyricInfo | null>(null);
+
+  const [lyricMapper] = useLyricMapper();
+
+  const onUpdate = (_event: unknown, message: { data: UpdateData }) => {
+    const data: UpdateData = message.data;
+
+    setOriginalData(data);
+    setStatus(data.status);
+    if (!data.status && data.playing === false) {
+      // for Spotify
+      setStatus('stopped');
+    }
+
+    if (typeof data.title === 'string') {
+      setTitle(data.title);
+    }
+
+    if (Array.isArray(data.artists)) {
+      setArtist(data.artists.join(', '));
+    }
+
+    setProgress(data.progress);
+    setDuration(data.duration);
+    setCoverUrl(
+      data.cover_url.match(/^(?:file|https?):\/\//) ? data.cover_url : IconMusic,
+    );
+  };
+
+  window.ipcRenderer.on('update', onUpdate);
+  onMount(() => {
+    setInterval(() => {
+      if (status() === 'playing') {
+        setProgress(progress() + 100);
+      }
+    }, 100);
+  });
+
+  onCleanup(() => window.ipcRenderer.off('update', originalData));
+
+  createEffect(on([title, coverUrl, lyricMapper], async () => {
+    const data = originalData();
+    const mapper = lyricMapper();
+
+    if (!data) return;
+
+    const id: number | undefined = mapper[`${data.title}:${data.cover_url}`];
+    console.log(id);
+    const lyricInfo = await (async () => {
+      const alsongLyric = (
+        typeof id === 'number'
+          ? await window.ipcRenderer.invoke('get-lyric-by-id', id) as (Lyric | null)
+          : await window.ipcRenderer.invoke('get-lyric', data) as Lyric
+      );
+
+    console.log(alsongLyric);
+      if (alsongLyric) {
+        return { kind: 'alsong', data: alsongLyric } as const;
+      }
+
+      if (data.lyric) {
+        return { kind: 'default', data } as const;
+      }
+
+      return null;
+    })();
+
+    setOriginalLyric(lyricInfo);
+    if (lyricInfo?.data.lyric) {
+      const treeMap = new TreeMap<number, string[]>();
+      for (const key in lyricInfo.data.lyric) {
+        treeMap.set(~~key, lyricInfo.data.lyric[key]);
+      }
+
+      setLyrics(treeMap);
+    } else {
+      setLyrics(null);
+    }
+  }));
+
+  const playingInfo = {
+    title,
+    artist,
+    progress,
+    duration,
+    status,
+    coverUrl,
+    lyrics,
+    originalData,
+    originalLyric,
+  } as PlayingInfo;
+
+  return (
+    <PlayingInfoContext.Provider value={playingInfo}>
+      {props.children}
+    </PlayingInfoContext.Provider>
+  );
+};
+
+export default PlayingInfoProvider;
+export const usePlayingInfo = () => useContext(PlayingInfoContext);

--- a/renderer/types.ts
+++ b/renderer/types.ts
@@ -8,4 +8,5 @@ export interface UpdateData {
   lyric: {
     [key: string]: string[];
   }
+  playing?: boolean;
 }

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -72,11 +72,21 @@ class Application {
         type: 'separator',
       },
       {
-        type: 'normal',
-        label: 'devtools',
-        click: () => {
-          this.mainWindow.webContents.openDevTools({ mode: 'detach' });
-        },
+        label: '개발자 도구',
+        submenu: [
+          {
+            label: '가사 표시기 창',
+            click: () => {
+              this.mainWindow?.webContents.openDevTools({ mode: 'detach' });
+            },
+          },
+          {
+            label: '가사 선택 창',
+            click: () => {
+              this.lyricsWindow?.webContents.openDevTools({ mode: 'detach' });
+            },
+          }
+        ]
       },
     ]);
 

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -85,6 +85,12 @@ class Application {
             click: () => {
               this.lyricsWindow?.webContents.openDevTools({ mode: 'detach' });
             },
+          },
+          {
+            label: '설정 창',
+            click: () => {
+              this.settingsWindow?.webContents.openDevTools({ mode: 'detach' });
+            },
           }
         ]
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 export interface TunaOBSPayload {
-  playing: boolean;
   title: string;
   artist: string;
   progress: number;


### PR DESCRIPTION
## 문제
* 가사에 시간보간이 되어있지 않아 Spotify 창이 최소화돼있을 경우 몇개의 가사가 스킵됩니다.
* Spotify 의 `playing: boolean` 이 적용되지 않아 일시중지가 표시되지 않습니다.

이를 수정하기 위해서는 여러군데를 수정해야 하는데, 이는 현재 가사 표시창과 가사 선택창 각각에 가사를 받아오고 선택하고 관리하는 로직이 따로 존재하기 때문입니다.

## 해결
* 가사 시간보간 및 `playing: boolean` 체크를 추가합니다.
* 가사 관리 로직을 `PlayingInfoProvider` 로 일원화합니다.

## 기타
* 가사 선택창에 현재 가사를 보여주는 기능을 추가하였습니다.
* 윈도우 앵커 스타일을 `AnchoredView` 컴포넌트로 분리하였습니다.