### PR TITLE
fix: high GPU usage

### DIFF
--- a/renderer/components/Marquee.tsx
+++ b/renderer/components/Marquee.tsx
@@ -53,7 +53,10 @@ const Marquee = (props: MarqueeProps) => {
     <div
       {...leftProps}
       ref={dom}
-      class={cx('relative whitespace-nowrap overflow-auto flex flex-row justify-start items-center remove-scrollbar', props.class)}
+      class={cx(
+        'relative whitespace-nowrap overflow-auto flex flex-row justify-start items-center remove-scrollbar will-change-scroll',
+        props.class,
+      )}
       classList={{
         ...leftProps.classList,
         'overflow-hidden': useMarquee(),

--- a/renderer/lyrics/SideBar.tsx
+++ b/renderer/lyrics/SideBar.tsx
@@ -97,7 +97,7 @@ const SideBar = () => {
           </div>
         </div>
       </Card>
-      <div class={'fluent-scrollbar flex-1 block text-center overflow-scroll overflow-x-visible overflow-y-auto'}>
+      <div class={'fluent-scrollbar flex-1 block text-center overflow-scroll overflow-x-visible overflow-y-auto will-change-scroll'}>
         <For each={lyricItems()}>
           {([time, value]) => (
             <div

--- a/renderer/main/components/LyricProgressBar.tsx
+++ b/renderer/main/components/LyricProgressBar.tsx
@@ -1,4 +1,4 @@
-import { createEffect, splitProps } from 'solid-js';
+import { createEffect, createSignal, splitProps } from 'solid-js';
 import icon from '../../../assets/icon_music.png';
 import Marquee from '../../components/Marquee';
 import { usePlayingInfo } from '../../components/PlayingInfoProvider';
@@ -22,7 +22,7 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
     props,
     ['class', 'style', 'progressClass', 'progressStyle', 'textClass', 'textStyle'],
   );
-  let progressDiv: HTMLDivElement;
+  const [progressTransition, setProgressTransition] = createSignal(false);
 
   let percent: number = 0;
   let oldPercent: number = 0;
@@ -32,13 +32,9 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
     percent = progress() / duration();
 
     if (Math.abs(percent - oldPercent) > 0.01) {
-      progressDiv.style.transitionProperty = 'transform';
-      progressDiv.style.transitionTimingFunction = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
-      progressDiv.style.transitionDuration = '225ms';
-    } else {
-      progressDiv.style.transitionProperty = 'none';
-      progressDiv.style.transitionTimingFunction = undefined;
-      progressDiv.style.transitionDuration = undefined;
+      setProgressTransition(true)
+    } else if (progressTransition()) {
+      setProgressTransition(false)
     }
   });
 
@@ -60,10 +56,10 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
       {...containerProps}
     >
       <div
-        ref={progressDiv}
         class={cx(
           `
             absolute inset-0 bg-gray-500 z-[-1] scale-x-[--percent] origin-left
+            ${progressTransition() ? 'transition-transform duration-225 ease-[cubic-bezier(0.34, 1.56, 0.64, 1)]' : ''}
           `,
           style.progressClass,
         )}

--- a/renderer/main/components/LyricProgressBar.tsx
+++ b/renderer/main/components/LyricProgressBar.tsx
@@ -77,7 +77,7 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
             ${status() === 'stopped' ? 'grayscale' : ''}
             ${status() === 'stopped' ? 'scale-95' : ''}
           `}
-         alt={'Thumbnail'}/>
+          alt={'Thumbnail'}/>
         <Marquee gap={32}>
           <div
             class={cx('w-fit flex flex-row justify-start items-center gap-2', style.textClass)}

--- a/renderer/main/components/LyricProgressBar.tsx
+++ b/renderer/main/components/LyricProgressBar.tsx
@@ -1,4 +1,4 @@
-import { splitProps } from 'solid-js';
+import { createEffect, splitProps } from 'solid-js';
 import icon from '../../../assets/icon_music.png';
 import Marquee from '../../components/Marquee';
 import { usePlayingInfo } from '../../components/PlayingInfoProvider';
@@ -22,12 +22,32 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
     props,
     ['class', 'style', 'progressClass', 'progressStyle', 'textClass', 'textStyle'],
   );
+  let progressDiv: HTMLDivElement;
+
+  let percent: number = 0;
+  let oldPercent: number = 0;
+
+  createEffect(() => {
+    oldPercent = percent;
+    percent = progress() / duration();
+
+    if (Math.abs(percent - oldPercent) > 0.01) {
+      progressDiv.style.transitionProperty = 'transform';
+      progressDiv.style.transitionTimingFunction = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
+      progressDiv.style.transitionDuration = '225ms';
+    } else {
+      progressDiv.style.transitionProperty = 'none';
+      progressDiv.style.transitionTimingFunction = undefined;
+      progressDiv.style.transitionDuration = undefined;
+    }
+  });
 
   return (
     <div
       style={`
         --percent: ${progress() / duration() * 100}%;
         opacity: ${status() === 'stopped' ? 0.5 : 1};
+        will-change: opacity, transform;
         ${style.style}
       `}
       class={cx(
@@ -40,10 +60,10 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
       {...containerProps}
     >
       <div
+        ref={progressDiv}
         class={cx(
           `
             absolute inset-0 bg-gray-500 z-[-1] scale-x-[--percent] origin-left
-            transition-all duration-225 ease-[cubic-bezier(0.34, 1.56, 0.64, 1)]
           `,
           style.progressClass,
         )}
@@ -57,7 +77,7 @@ const LyricProgressBar = (props: LyricProgressBarProps) => {
             ${status() === 'stopped' ? 'grayscale' : ''}
             ${status() === 'stopped' ? 'scale-95' : ''}
           `}
-        />
+         alt={'Thumbnail'}/>
         <Marquee gap={32}>
           <div
             class={cx('w-fit flex flex-row justify-start items-center gap-2', style.textClass)}

--- a/renderer/main/components/LyricsItem.tsx
+++ b/renderer/main/components/LyricsItem.tsx
@@ -29,6 +29,7 @@ const LyricsItem = (props: LyricsItemProps) => {
 
   onMount(() => {
     dom.addEventListener('transitionend', () => {
+      dom.style.willChange = 'auto';
       setInit(true);
     }, { once: true });
   });
@@ -38,11 +39,11 @@ const LyricsItem = (props: LyricsItemProps) => {
       {...leftProps}
       ref={dom}
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      style={local.status === 'stopped' ? `${style()} opacity: 0.5; ${props.style}` : `${style()}; ${props.style}`}
+      style={local.status === 'stopped' ? `${style()} opacity: 0.5; ${props.style as string}` : `${style()}; ${props.style as string}`}
       class={cx(`
         py-1 px-2 whitespace-pre-line text-center
         bg-gray-900/50 text-gray-100
-        transition-all duration-[225ms] ease-out origin-right
+        transition-all duration-[225ms] ease-out origin-right will-change-transform
       `, leftProps.class)}
     >
       {leftProps.children}


### PR DESCRIPTION
# 요약

- Progress bar가 1% 이상 변경된 경우에만 트랜지션을 적용하게 끔 변경하여, GPU를 항시 5% 이상 점유하고 있던 문제를 해결합니다.
- `will-change: scroll-position` 속성을 자동 스크롤 관련 div에 적용 (현재 가사, Marquee)

## 패치 이전

### GPU 점유율

![image](https://github.com/organization/alspotron/assets/16558115/1a8497b6-e543-4b24-9874-1db65b7f25fc)

- 차례대로 dwm, Electron
- 잦은 트랜지션으로 인해 최상단의 dwm 프로세스도 영향을 받음

### 프로파일링

![image](https://github.com/organization/alspotron/assets/16558115/d865e404-d91e-43c1-bc3c-67ea31c1c742)

![image](https://github.com/organization/alspotron/assets/16558115/0977abc0-712c-4d0b-a6ef-b2e55f2aaecc)


- 불필요한 애니메이션이 잦은 것을 알 수 있음


## 패치 이후

### GPU 점유율

![image](https://github.com/organization/alspotron/assets/16558115/da549211-867c-4a80-b3eb-5375598ed6d9)

- 차례대로 Electron
- dwm은 영향을 받지 않고, Electron 자체의 GPU 사용량도 크게 줄어든 모습

### 프로파일링

![image](https://github.com/organization/alspotron/assets/16558115/55fc6e46-aa11-4f35-9ecf-85ca62dd8c99)

- 불필요한 애니메이션이 크게 줄어든 모습

# 한계

- Marquee는 스크롤이라는 특성 상 GPU 사용량을 줄일 수가 없을 듯