### PR TITLE
feat: use sorted vectors instead of tree-based associative map / use TSTL instead of js-sdsl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.4.3",
-        "@js-sdsl/ordered-map": "^4.4.1",
         "@koa/cors": "^4.0.0",
         "@popperjs/core": "^2.11.8",
         "alsong": "^3.0.1",
@@ -1771,15 +1770,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
-    },
-    "node_modules/@js-sdsl/ordered-map": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.1.tgz",
-      "integrity": "sha512-ggzDj84wgn5tnY8k4wqC8jqPvxZvavHodvnOvGAe5EBmiBBN+SPe97EATBCpcgqlDucTN5wN/0Li9c8qN4/FTQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
-      }
     },
     "node_modules/@koa/cors": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "opentype.js": "^1.3.4",
         "solid-floating-ui": "^0.2.1",
         "solid-js": "^1.7.8",
-        "solid-transition-group": "^0.2.2"
+        "solid-transition-group": "^0.2.2",
+        "tstl": "^2.5.13"
       },
       "devDependencies": {
         "@total-typescript/ts-reset": "^0.4.2",
@@ -10629,6 +10630,11 @@
       "engines": {
         "node": ">=0.6.x"
       }
+    },
+    "node_modules/tstl": {
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/tstl/-/tstl-2.5.13.tgz",
+      "integrity": "sha512-h9wayHHFI5+yqt8iau0vqH96cTNhezhZ/Fk/hrIdpfkiMu3lg9nzyvMfs5bIdX51IVzZO6DudLqhkL/rVXpT6g=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.4.3",
-    "@js-sdsl/ordered-map": "^4.4.1",
     "@koa/cors": "^4.0.0",
     "@popperjs/core": "^2.11.8",
     "alsong": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@koa/cors": "^4.0.0",
     "@popperjs/core": "^2.11.8",
     "alsong": "^3.0.1",
+    "tstl": "^2.5.13",
     "color": "^4.2.3",
     "deepmerge": "^4.3.1",
     "electron-updater": "^6.1.1",
@@ -76,8 +77,8 @@
   },
   "optionalDependencies": {
     "@jellybrick/wql-process-monitor": "^1.4.5",
-    "hmc-win32": "^1.3.6",
-    "exe-icon-extractor": "^1.0.8"
+    "exe-icon-extractor": "^1.0.8",
+    "hmc-win32": "^1.3.6"
   },
   "overrides": {
     "xml2js": "0.6.0",

--- a/renderer/components/PlayingInfoProvider.tsx
+++ b/renderer/components/PlayingInfoProvider.tsx
@@ -1,4 +1,4 @@
-import { OrderedMap } from '@js-sdsl/ordered-map';
+import tstl from 'tstl';
 import alsong from 'alsong';
 import { Accessor, createContext, createEffect, createSignal, JSX, on, onCleanup, onMount, useContext } from 'solid-js';
 
@@ -14,7 +14,7 @@ type PlayingInfo = {
   artist: Accessor<string>;
   status: Accessor<'idle' | 'playing' | 'stopped'>;
   coverUrl: Accessor<string>;
-  lyrics: Accessor<OrderedMap<number, string[]> | null>;
+  lyrics: Accessor<tstl.experimental.FlatMap<number, string[]> | null>;
   originalData: Accessor<UpdateData | null>;
   originalLyric: Accessor<LyricInfo | null>;
 };
@@ -41,7 +41,7 @@ const PlayingInfoProvider = (props: { children: JSX.Element }) => {
   const [artist, setArtist] = createSignal('N/A');
   const [status, setStatus] = createSignal('idle');
   const [coverUrl, setCoverUrl] = createSignal<string>();
-  const [lyrics, setLyrics] = createSignal<OrderedMap<number, string[]> | null>(null);
+  const [lyrics, setLyrics] = createSignal<tstl.experimental.FlatMap<number, string[]> | null>(null);
   const [originalData, setOriginalData] = createSignal<UpdateData | null>(null);
   const [originalLyric, setOriginalLyric] = createSignal<LyricInfo | null>(null);
 
@@ -104,11 +104,10 @@ const PlayingInfoProvider = (props: { children: JSX.Element }) => {
 
     setOriginalLyric(lyricInfo);
     if (lyricInfo?.data.lyric) {
-      const treeMap = new OrderedMap<number, string[]>();
-      const iter = treeMap.begin();
+      const treeMap = new tstl.experimental.FlatMap<number, string[]>();
 
       for (const key in lyricInfo.data.lyric) {
-        treeMap.setElement(~~key, lyricInfo.data.lyric[key], iter);
+        treeMap.emplace(~~key, lyricInfo.data.lyric[key]);
       }
 
       setLyrics(treeMap);

--- a/renderer/hooks/useLyric.ts
+++ b/renderer/hooks/useLyric.ts
@@ -11,17 +11,17 @@ const useLyric = () => {
     const tempLyrics = lyrics();
     if (tempLyrics === null) return null;
 
-    const last = tempLyrics.lowerBound(progress() + BIAS + TRANSITION_DURATION);
+    const last = tempLyrics.lower_bound(progress() + (BIAS + TRANSITION_DURATION));
 
     if (!last.equals(tempLyrics.begin()) && last !== tempLyrics.begin()) {
-      return last.pre();
+      return last.prev();
     }
 
     return last;
   };
 
-  const lyric = createMemo(() => lastIter()?.pointer[1]);
-  const index = createMemo(() => lastIter()?.pointer[0]);
+  const lyric = createMemo(() => lastIter()?.second);
+  const index = createMemo(() => lastIter()?.first);
 
   return [lyric, index] as const;
 };

--- a/renderer/lyrics/SideBar.tsx
+++ b/renderer/lyrics/SideBar.tsx
@@ -20,7 +20,12 @@ const SideBar = () => {
   const lyricItems = createMemo(() => {
     const items: [number, string[]][] = [];
 
-    lyrics()?.forEach((item) => items.push(item));
+    const tempLyrics = lyrics();
+    if (tempLyrics !== null) {
+      for (let it = tempLyrics.begin(); it !== tempLyrics.end(); it = it.next()) {
+        items.push([it.first, it.second]);
+      }
+    }
 
     return items;
   });


### PR DESCRIPTION
> It seems as if we're better off with a sorted vector. The disadvantages of a sorted vector are linear-time insertions and linear-time deletions (...). In exchange, a vector offers about twice the lookup speed and a much smaller working set (...). Loki saves the trouble of maintaining a sorted vector by hand by defining an AssocVector class template. AssocVector is a drop-in replacement for std::map (it supports the same set of member functions), implemented on top of std::vector. AssocVector differs from a map in the behavior of its erase functions (AssocVector::erase invalidates all iterators into the object) and in the complexity guarantees of insert and erase (linear as opposed to constant). 

# Before

![image](https://github.com/organization/alspotron/assets/16558115/18b74fb1-98a3-4751-a5a2-ca5c77cc8933)

# After

![image](https://github.com/organization/alspotron/assets/16558115/f259035d-603b-4a44-a3d8-10d7f7bf18fd)
