### PR TITLE
Fix: https://github.com/organization/alspotron/issues/54

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -577,7 +577,6 @@ class Application {
     if (this.settingsWindow instanceof MicaBrowserWindow) {
       this.settingsWindow.setDarkTheme();
       this.settingsWindow.setMicaEffect();
-      this.settingsWindow.show();
     }
 
     this.settingsWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -591,6 +590,8 @@ class Application {
     } else {
       this.settingsWindow.loadURL('http://localhost:5173/settings.html');
     }
+
+    this.settingsWindow.show();
   }
 
   initLyricsWindow() {
@@ -614,7 +615,6 @@ class Application {
     if (this.lyricsWindow instanceof MicaBrowserWindow) {
       this.lyricsWindow.setDarkTheme();
       this.lyricsWindow.setMicaEffect();
-      this.lyricsWindow.show();
     }
 
     if (app.isPackaged) {
@@ -622,6 +622,8 @@ class Application {
     } else {
       this.lyricsWindow.loadURL('http://localhost:5173/lyrics.html');
     }
+
+    this.lyricsWindow.show();
   }
 
   injectOverlay() {


### PR DESCRIPTION
## 버그 발생 요약

`this.lyricsWindow = new (IS_WINDOWS_11 ? MicaBrowserWindow : GlassBrowserWindow)({`

Windows 11에서만 `MicaBrowserWindow ` 인스턴스로 창이 생기지만

```
if (this.lyricsWindow instanceof MicaBrowserWindow) {
  ...
  this.lyricsWindow.show();
}
```
`[window].show()` 가 `MicaBrowserWindow` 일때만 호출되는 문제

## 수정사항
- `[window].show()` 위치 조정