### PR TITLE
refactor: Transition 버그 수정 및 리팩토링

### DIFF
--- a/renderer/components/PlayingInfoProvider.tsx
+++ b/renderer/components/PlayingInfoProvider.tsx
@@ -6,9 +6,9 @@ import IconMusic from '../../assets/icon_music.png';
 import useLyricMapper from '../hooks/useLyricMapper';
 import { UpdateData } from '../types';
 
-type Lyric = Awaited<ReturnType<typeof alsong.getLyricById>>;
-type Status = 'idle' | 'playing' | 'stopped';
-type PlayingInfo = {
+export type Lyric = Awaited<ReturnType<typeof alsong.getLyricById>>;
+export type Status = 'idle' | 'playing' | 'stopped';
+export type PlayingInfo = {
   progress: Accessor<number>;
   duration: Accessor<number>;
   title: Accessor<string>;
@@ -20,7 +20,7 @@ type PlayingInfo = {
   originalLyric: Accessor<LyricInfo | null>;
 };
 
-type LyricInfo =
+export type LyricInfo =
   | { useMapper: boolean, kind: 'alsong', data: Lyric }
   | { useMapper: boolean, kind: 'default', data: UpdateData };
 

--- a/renderer/main/components/Lyrics.tsx
+++ b/renderer/main/components/Lyrics.tsx
@@ -1,64 +1,18 @@
-import { createMemo, For, splitProps } from 'solid-js';
-import { TransitionGroup } from 'solid-transition-group'
 
-import LyricsItem from './LyricsItem'
+import { splitProps } from 'solid-js';
+
+import LyricsTransition from './LyricsTransition';
 
 import { usePlayingInfo } from '../../components/PlayingInfoProvider';
-import useConfig from '../../hooks/useConfig';
 import useLyric from '../../hooks/useLyric';
-import { cx } from '../../utils/classNames';
-import { userCSSSelectors, userCSSTransitions } from '../../utils/userCSSSelectors';
 
 import type { JSX } from 'solid-js/jsx-runtime';
 
 const Lyrics = (props: JSX.HTMLAttributes<HTMLDivElement>) => {
-  const [config] = useConfig();
   const [, containerProps] = splitProps(props, ['class']);
   const { status } = usePlayingInfo();
-  const [lyric] = useLyric();
-
-  const animation = () => {
-    const configuredName = config()?.style?.animation ?? 'pretty';
-    if (configuredName === 'custom') {
-      return userCSSTransitions['transition-lyric'];
-    }
-
-    return `lyric-${configuredName}`;
-  };
-
-  const style = createMemo(() => {
-    const result: Record<string, string> = {
-      'text-align': 'var(--text-align)',
-    };
-    const configData = config();
-    
-    if (configData?.style?.font) result['font-family'] = configData?.style.font;
-    if (configData?.style?.fontWeight) result['font-weight'] = configData?.style.fontWeight;
-    if (configData?.style?.lyric?.fontSize) result['font-size'] = `${configData.style.lyric.fontSize}px`;
-    if (configData?.style?.lyric?.color) result['color'] = configData?.style.lyric.color;
-    if (configData?.style?.lyric?.background) result['background-color'] = configData?.style.lyric.background;
-
-    return Object.entries(result).map(([key, value]) => `${key}: ${value};`).join(' ');
-  });
-
-  return (
-    <div class={cx('flex flex-col items-end gap-4', userCSSSelectors.lyrics, props.class)} {...containerProps}>
-      <TransitionGroup name={`${animation()}`}>
-        <For each={lyric() ?? []}>
-          {(item, index) => item && (
-            <LyricsItem
-              class={userCSSSelectors['lyrics-item']}
-              status={status()}
-              delay={animation() === 'none' ? 0 : index()}
-              style={style()}
-            >
-              {item}
-            </LyricsItem>
-          )}
-        </For>
-      </TransitionGroup>
-    </div>
-  );
-};
+  const [lyrics] = useLyric();
+  return <LyricsTransition lyrics={lyrics() ?? []} status={status()} {...containerProps} />
+}
 
 export default Lyrics;

--- a/renderer/main/components/Lyrics.tsx
+++ b/renderer/main/components/Lyrics.tsx
@@ -6,13 +6,32 @@ import LyricsTransition from './LyricsTransition';
 import { usePlayingInfo } from '../../components/PlayingInfoProvider';
 import useLyric from '../../hooks/useLyric';
 
+import { cx } from '../../utils/classNames';
+import { userCSSSelectors } from '../../utils/userCSSSelectors';
+
+import useConfig from '../../hooks/useConfig';
+
 import type { JSX } from 'solid-js/jsx-runtime';
 
-const Lyrics = (props: JSX.HTMLAttributes<HTMLDivElement>) => {
-  const [, containerProps] = splitProps(props, ['class']);
+type LyricsProps = {
+  style?: string;
+} & JSX.HTMLAttributes<HTMLDivElement>;
+
+const Lyrics = (props: LyricsProps) => {
+  const [config] = useConfig();
+  const [, containerProps] = splitProps(props, ['class', 'style']);
   const { status } = usePlayingInfo();
   const [lyrics] = useLyric();
-  return <LyricsTransition lyrics={lyrics() ?? []} status={status()} {...containerProps} />
+
+  return (
+    <div
+      class={cx('w-full flex flex-col items-end', props.class, userCSSSelectors['lyrics-wrapper'])}
+      style={`opacity: ${status() !== 'playing' ? config()?.style.lyric.stoppedOpacity : 1}; ${props.style ?? ''};`}
+      {...containerProps}
+    >
+      <LyricsTransition lyrics={lyrics() ?? []} status={status()} {...containerProps} />
+    </div>
+  );
 }
 
 export default Lyrics;

--- a/renderer/main/components/LyricsItem.tsx
+++ b/renderer/main/components/LyricsItem.tsx
@@ -13,7 +13,6 @@ export interface LyricsItemProps extends JSX.HTMLAttributes<HTMLDivElement> {
 }
 
 const LyricsItem = (props: LyricsItemProps) => {
-  const [config] = useConfig();
   const [local, leftProps] = splitProps(props, ['status']);
 
   let dom!: HTMLDivElement;
@@ -27,7 +26,6 @@ const LyricsItem = (props: LyricsItemProps) => {
       top: ${dom.offsetTop}px;
       transition-delay: calc(var(--order) * 75ms);
       scale: ${local.status === 'stopped' ? '0.95' : '1'};
-      opacity: ${local.status !== 'playing' ? config()?.style.lyric.stoppedOpacity : 1};
     `;
   });
 

--- a/renderer/main/components/LyricsItem.tsx
+++ b/renderer/main/components/LyricsItem.tsx
@@ -1,5 +1,6 @@
 import { createMemo, createSignal, onMount, splitProps } from 'solid-js';
 
+import { Status } from '../../components/PlayingInfoProvider';
 import useConfig from '../../hooks/useConfig';
 import { cx } from '../../utils/classNames';
 
@@ -8,24 +9,23 @@ import type { JSX } from 'solid-js/jsx-runtime';
 export interface LyricsItemProps extends JSX.HTMLAttributes<HTMLDivElement> {
   children: JSX.Element;
   style?: string;
-  status?: string;
-  delay?: number;
+  status?: Status;
 }
 
 const LyricsItem = (props: LyricsItemProps) => {
   const [config] = useConfig();
-  const [local, leftProps] = splitProps(props, ['status', 'delay']);
+  const [local, leftProps] = splitProps(props, ['status']);
 
   let dom!: HTMLDivElement;
 
   const [init, setInit] = createSignal(false);
 
   const style = createMemo(() => {
-    if (!init()) return `transition-delay: ${225 + ((local.delay ?? 0) * 75)}ms;`;
+    if (!init()) return 'transition-delay: calc(255ms + var(--order) * 75ms);';
 
     return `
       top: ${dom.offsetTop}px;
-      transition-delay: ${(local.delay ?? 0) * 75}ms;
+      transition-delay: calc(var(--order) * 75ms);
       scale: ${local.status === 'stopped' ? '0.95' : '1'};
       opacity: ${local.status !== 'playing' ? config()?.style.lyric.stoppedOpacity : 1};
     `;

--- a/renderer/main/components/LyricsTransition.tsx
+++ b/renderer/main/components/LyricsTransition.tsx
@@ -1,0 +1,127 @@
+import { createMemo, For, JSX, on, Show, splitProps, untrack } from 'solid-js';
+import { TransitionGroup } from 'solid-transition-group';
+
+import LyricsItem from './LyricsItem';
+
+import { Status } from '../../components/PlayingInfoProvider';
+import useConfig from '../../hooks/useConfig';
+import { cx } from '../../utils/classNames';
+import { userCSSSelectors, userCSSTransitions, userCSSVariables } from '../../utils/userCSSSelectors';
+
+type LyricsProps = {
+  lyrics: string[];
+  status: Status;
+  style: string;
+};
+
+const Lyrics = (props: LyricsProps) => (
+  <For each={props.lyrics}>
+    {(item, index) => item && (
+      <LyricsItem
+        class={userCSSSelectors['lyrics-item']}
+        status={props.status}
+        style={`
+          --order: ${index()};
+          ${userCSSVariables['var-lyric-order']}: var(--order);
+          ${props.style};
+        `}
+      >
+        {item}
+      </LyricsItem>
+    )}
+  </For>
+);
+
+type LyricsTransitionGroupProps = {
+  animation: string;
+  lyrics: string[];
+  lyricsStyle: string;
+  lyricsStatus: Status;
+  container: ({ children }: { children: JSX.Element }) => JSX.Element;
+};
+
+const LyricsTransitionGroupAllAtOnce = (props: LyricsTransitionGroupProps) => {
+  const lyricTransitionGroup = () => [props.lyrics];
+  const Container = untrack(() => props.container);
+
+  return (
+    <TransitionGroup name={props.animation} appear>
+      <For each={lyricTransitionGroup()}>
+        {(lyrics) => (
+          <Container>
+            <Lyrics lyrics={lyrics} style={props.lyricsStyle} status={props.lyricsStatus} />
+          </Container>
+        )}
+      </For>
+    </TransitionGroup>
+  );
+};
+
+const LyricsTransitionGroupSequential = (props: LyricsTransitionGroupProps) => {
+  const Container = untrack(() => props.container);
+
+  return (
+    <Container>
+      <TransitionGroup name={props.animation} appear>
+        <Lyrics lyrics={props.lyrics} style={props.lyricsStyle} status={props.lyricsStatus} />
+      </TransitionGroup>
+    </Container>
+  );
+};
+
+type LyricTransitionProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  lyrics: string[];
+  status: Status;
+};
+
+const LyricsTransition = (props: LyricTransitionProps) => {
+  const [, lyricsProps, passedProps] = splitProps(props, ['class'], ['lyrics', 'status']);
+
+  const animation = () => {
+    const configuredName = config()?.style?.animation ?? 'pretty';
+    if (configuredName === 'custom') {
+      return userCSSTransitions['transition-lyric'];
+    }
+
+    return `lyric-${configuredName}`;
+  };
+
+  const [config] = useConfig();
+  const lyricsStyle = createMemo(on(config, (configData) => `
+    ${configData ? `
+      font-family: ${configData.style.font};
+      font-weight: ${configData.style.fontWeight};
+      font-size: ${configData.style.lyric.fontSize}px;
+      color: ${configData.style.lyric.color};
+      background-color: ${configData.style.lyric.background};
+    ` : ''};
+    text-align: var(--text-align);
+  `));
+
+  const Container = (containerProps: { children: JSX.Element }) => (
+    <div class={cx('flex flex-col items-end gap-4', userCSSSelectors.lyrics, props.class)} {...passedProps}>
+      {containerProps.children}
+    </div>
+  );
+
+  const LyricsTransitionGroup = (transitionProps: LyricsTransitionGroupProps) => (
+    <Show
+      when={config()?.style.animationAtOnce}
+      fallback={<LyricsTransitionGroupAllAtOnce {...transitionProps} />}
+    >
+      <LyricsTransitionGroupSequential {...transitionProps} />
+    </Show>
+  );
+
+  return (
+    <LyricsTransitionGroup 
+      animation={animation()}
+      container={Container}
+      lyrics={lyricsProps.lyrics}
+      lyricsStatus={lyricsProps.status}
+      lyricsStyle={lyricsStyle()}
+    />
+  );
+};
+
+export default LyricsTransition;

--- a/renderer/main/components/LyricsTransition.tsx
+++ b/renderer/main/components/LyricsTransition.tsx
@@ -107,9 +107,9 @@ const LyricsTransition = (props: LyricTransitionProps) => {
   const LyricsTransitionGroup = (transitionProps: LyricsTransitionGroupProps) => (
     <Show
       when={config()?.style.animationAtOnce}
-      fallback={<LyricsTransitionGroupAllAtOnce {...transitionProps} />}
+      fallback={<LyricsTransitionGroupSequential {...transitionProps} />}
     >
-      <LyricsTransitionGroupSequential {...transitionProps} />
+      <LyricsTransitionGroupAllAtOnce {...transitionProps} />
     </Show>
   );
 

--- a/renderer/settings/containers/ThemeContainer.tsx
+++ b/renderer/settings/containers/ThemeContainer.tsx
@@ -46,20 +46,25 @@ const ThemeContainer = () => {
     return `알 수 없음(${value})`;
   };
 
-  const [animationPreview, setAnimationPreview] = createSignal([
+  const PREVIEW_TEXT_A = [
     '가사 전환 애니메이션 미리보기용 가사입니다',
     'https://github.com/organization/alspotron',
-    '가사 전환 애니메이션을 바꾸는 중간에는 끊길수 있습니다'
-  ]);
+    '가사 전환 애니메이션을 바꾸는 중간에는 끊길수 있습니다',
+  ];
+
+  const PREVIEW_TEXT_B = [
+    '계절이 지나가는 하늘에는',
+    '가을로 가득 차 있습니다.',
+    '나는 아무 걱정도 없이'
+  ];
+
+  const [animationPreview, setAnimationPreview] = createSignal(PREVIEW_TEXT_A);
 
   let interval: NodeJS.Timer | null = null;
   onMount(() => {
     let isTick = false;
     interval = setInterval(() => {
-      const nextPreview = untrack(() => animationPreview()
-        .slice()
-        .map((lyric) => `${lyric}${isTick ? ' ' : ''}`)
-      );
+      const nextPreview = untrack(() => isTick ? PREVIEW_TEXT_A : PREVIEW_TEXT_B);
 
       isTick = !isTick;
       setAnimationPreview(nextPreview);
@@ -166,7 +171,7 @@ const ThemeContainer = () => {
               미리보기
             </div>
             <div class={'relative w-full h-32 flex flex-col justify-start items-start gap-4'}>
-              <LyricsTransition lyrics={animationPreview()} status="playing" />
+              <LyricsTransition class={'w-full'} lyrics={animationPreview()} status="playing" />
             </div>
           </div>,
           <div class={'w-full h-full flex justify-start items-center'}>
@@ -189,7 +194,19 @@ const ThemeContainer = () => {
                 {getAnimationName(option)}
               </li>}
             />
-          </div>
+          </div>,
+          <div class={'w-full h-full flex justify-start items-center'}>
+            <div class={'text-md'}>
+              한번에 전환
+            </div>
+            <div class={'flex-1'} />
+            <input
+              class={'checkbox'}
+              type="checkbox" 
+              checked={config()?.style?.animationAtOnce}
+              onChange={({ target: { checked } }) => setConfig({ style: { animationAtOnce: checked } })}
+            />
+          </div>,
         ]}
       >
         <div class={'text-md'}>

--- a/renderer/settings/containers/ThemeContainer.tsx
+++ b/renderer/settings/containers/ThemeContainer.tsx
@@ -1,5 +1,4 @@
-import { Show, createSignal, onCleanup, onMount } from 'solid-js';
-import { TransitionGroup } from 'solid-transition-group';
+import { Show, createSignal, onCleanup, onMount, untrack } from 'solid-js';
 
 import { Config } from '../../../src/config';
 import Card from '../../components/Card';
@@ -7,7 +6,7 @@ import Selector from '../../components/Select';
 
 import useConfig from '../../hooks/useConfig';
 import useHorizontalScroll from '../../hooks/useHorizontalScroll';
-import LyricsItem from '../../main/components/LyricsItem';
+import LyricsTransition from '../../main/components/LyricsTransition';
 import ColorPicker from '../components/ColorPicker';
 import UserCSSEditor from '../components/UserCSSEditor';
 
@@ -24,25 +23,15 @@ const ANIMATION_LIST = [
 
 const ThemeContainer = () => {
   // eslint-disable-next-line prefer-const
-  let presetContainer: HTMLDivElement | undefined;
-  let interval: NodeJS.Timer | null = null;
+  let presetContainer: HTMLDivElement | null = null;
+  onMount(() => presetContainer && useHorizontalScroll(presetContainer));
 
   const [config, setConfig] = useConfig();
   const [fontList, setFontList] = createSignal<string[]>([]);
-  const [preview, setPreview] = createSignal(false);
 
   (async () => {
     setFontList(await window.getFont({ disableQuoting: true }));
   })();
-
-  onMount(() => {
-    if (presetContainer) useHorizontalScroll(presetContainer);
-
-    interval = setInterval(() => setPreview(!preview()), 1500);
-  });
-  onCleanup(() => {
-    if (interval) clearInterval(interval);
-  });
 
   const getAnimationName = (value: string) => {
     if (value === 'none') return '없음';
@@ -56,6 +45,27 @@ const ThemeContainer = () => {
 
     return `알 수 없음(${value})`;
   };
+
+  const [animationPreview, setAnimationPreview] = createSignal([
+    '가사 전환 애니메이션 미리보기용 가사입니다',
+    'https://github.com/organization/alspotron',
+    '가사 전환 애니메이션을 바꾸는 중간에는 끊길수 있습니다'
+  ]);
+
+  let interval: NodeJS.Timer | null = null;
+  onMount(() => {
+    let isTick = false;
+    interval = setInterval(() => {
+      const nextPreview = untrack(() => animationPreview()
+        .slice()
+        .map((lyric) => `${lyric}${isTick ? ' ' : ''}`)
+      );
+
+      isTick = !isTick;
+      setAnimationPreview(nextPreview);
+    }, 1500);
+  });
+  onCleanup(() => interval && clearInterval(interval));
 
   return <div class={'flex-1 flex flex-col justify-start items-stretch gap-1 py-4 fluent-scrollbar'}>
     <div class={'text-3xl mb-1 px-4'}>
@@ -156,22 +166,7 @@ const ThemeContainer = () => {
               미리보기
             </div>
             <div class={'relative w-full h-32 flex flex-col justify-start items-start gap-4'}>
-              <TransitionGroup name={`lyric-${config()?.style?.animation ?? 'pretty'}`}>
-                <Show when={preview()}>
-                  <LyricsItem delay={0}>
-                    가사 전환 애니메이션 미리보기용 가사입니다
-                  </LyricsItem>
-                  <LyricsItem
-                    delay={config()?.style?.animation === 'none' ? 0 : 1}>
-                    https://github.com/organization/alspotron
-                  </LyricsItem>
-                  <LyricsItem
-                    delay={config()?.style?.animation === 'none' ? 0 : 2}
-                  >
-                    가사 전환 애니메이션을 바꾸는 중간에는 끊길수 있습니다
-                  </LyricsItem>
-                </Show>
-              </TransitionGroup>
+              <LyricsTransition lyrics={animationPreview()} status="playing" />
             </div>
           </div>,
           <div class={'w-full h-full flex justify-start items-center'}>

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -33,6 +33,15 @@
       outline-none select-none;
   }
 
+  .checkbox {
+    @apply appearance-none w-[20px] h-[20px] bg-gray-100/5 rounded-[4px] hover:bg-gray-100/10 focus:bg-black/10
+    border-[1px] border-gray-100/20
+  }
+
+  .checkbox:checked {
+    @apply shadow-[inset_0_0_0_3px] shadow-primary-600
+  }
+
   .input {
     @apply bg-gray-100/5 text-white rounded-[4px] hover:bg-gray-100/10 focus:bg-black/10
     border-[1px] border-gray-100/[2%] border-b-gray-100/20 focus:border-b-2 focus:border-b-primary-500 focus:border-gray-100/10

--- a/renderer/utils/userCSSSelectors.ts
+++ b/renderer/utils/userCSSSelectors.ts
@@ -2,6 +2,7 @@ export const userCSSSelectors = {
   'wrapper': 'alspotron-usercss-wrapper',
   'lyrics-item': 'alspotron-usercss-lyrics-item',
   'lyrics': 'alspotron-usercss-lyrics',
+  'lyrics-wrapper': 'alspotron-usercss-lyrics-wrapper',
   'nowplaying': 'alspotron-usercss-nowplaying',
   'nowplaying-progress': 'alspotron-usercss-nowplaying-progress',
   'nowplaying-progress-bar': 'alspotron-usercss-nowplaying-progress-bar',

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface Config {
     font: string;
     fontWeight: string;
     animation: string;
+    animationAtOnce: boolean;
     maxHeight: number;
     proximityOpacity: number;
     proximitySensitivity: number;
@@ -56,6 +57,7 @@ export const DEFAULT_CONFIG = {
     font: 'KoPubWorldDotum',
     fontWeight: '400',
     animation: 'pretty',
+    animationAtOnce: false,
     maxHeight: 400,
     proximityOpacity: 0,
     proximitySensitivity: 2,


### PR DESCRIPTION
## 문제점
* Transition의 Opacity 가 제대로 적용되지 않는다.
* 같은 가사 트랜지션 코드가 설정과 실제 송출 2군데에 들어가있습니다.
* 모든 가사의 트랜지션을 동시에 진행할지 여부가 애니메이션 이름에 의존성을 가집니다.
~~* 가사 트랜지션 시 아래로 이동하는 동작이 있다. (position: absolute 이슈)~~[^1]

## 해결법
* LyricItem의 일시정지 시 투명 로직을 Lyrics로 옮긴다.
* 트랜지션 코드를 리팩토링해서 옮긴다.
* 트랜지션 동시진행 여부를 명시적으로 결정하게 한다.
~~* 동시진행하는 케이스에 한해서 모든 가사의 트랜지션을 묶는다. (미봉책)~~

## 기타
* UserCSS로 수정할 수 있는 Transition의 범위를 넓혔습니다.

[^1]: Transition 상위에 div가 없어서 생기는 버그로 수정되었습니다.