### PR TITLE
fix: migration always fails on new config

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,3 +1,6 @@
+import packageJson from '../package.json';
+
+export const VERSION = packageJson.version;
 export const DEFAULT_STYLE = {
   font: 'Pretendard JP Variable',
   fontWeight: '400',
@@ -105,6 +108,9 @@ export const DEFAULT_CONFIG = {
     config: {},
   },
 
+  __internal__: {
+    version: VERSION,
+  },
 };
 
 export const PRESET_PREFIX = '__preset__';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,9 +9,8 @@ import { createMigrator, migrateTable } from './migration';
 
 import { State } from './state';
 
+import { VERSION } from '../../common/constants';
 import { ConfigSchema, GameListSchema, LyricMapperSchema, ThemeListSchema } from '../../common/schema';
-
-import packageJson from '../../package.json';
 
 let resolver: () => void = () => null;
 const init = {
@@ -52,7 +51,7 @@ const tryMigration = () => {
   if (isLoaded) {
     const internalConfig = config.get()['__internal__'];
     const prevVersion = typeof internalConfig?.version === 'string' ? internalConfig.version : '0.0.0';
-    const nowVersion = packageJson.version;
+    const nowVersion = VERSION;
     console.log('[Alspotron] prepare for migration', prevVersion, '->', nowVersion);
 
     const migrator = createMigrator(migrateTable, prevVersion);

--- a/src/config/migration/runner.ts
+++ b/src/config/migration/runner.ts
@@ -19,7 +19,7 @@ export const createMigrator = (table: MigrateTable, prevVersion: string) => {
       const bMin = minVersion(b);
 
       if (!aMin || !bMin) return 0;
-      return lt(aMin, bMin) ? 1 : -1;
+      return lt(aMin, bMin) ? -1 : 1;
     })
     .map(([matcher, migrator]) => {
       if (clean(matcher) !== null) {
@@ -31,8 +31,7 @@ export const createMigrator = (table: MigrateTable, prevVersion: string) => {
         return migrator;
       }
     })
-    .filter(Boolean)
-    .reverse();
+    .filter(Boolean);
 
   return (initData: MigratorData) => {
     const result = { ...initData };


### PR DESCRIPTION
# Background
* #1279
* When the new config is initialized, the migrator tries to migrate from `0.0.0` to `latest`
	1. But the config is not compatible with `0.16` config
	2. Migrator fails
	3. Setting `__internal__.version` fails
	4. At next startup, the migrator tries to migrate
	5. (Repeat)

# Changes
* Set `__internal__.version` in `DEFAULT_CONFIG`