### PR TITLE
fix(spotify): fix broken spotify lyrics

### DIFF
--- a/src/provider/source/tuna-obs.ts
+++ b/src/provider/source/tuna-obs.ts
@@ -164,8 +164,9 @@ export class TunaObsProvider extends BaseSourceProvider {
     };
 
     if (data.data.status === 'playing' || data.data.status === 'paused') {
-      const lastLyric = this.lastUpdateData?.data.type !== 'idle'
-        ? this.lastUpdateData?.data.playerLyrics
+      const id = `${data.data.title}:${data.data.cover_url}`;
+      const lastLyric = this.lastUpdateData?.data.type !== 'idle' && this.lastUpdateData?.data.id === id
+        ? this.lastUpdateData.data.playerLyrics
         : undefined;
 
       result.data = {

--- a/src/provider/source/tuna-obs.ts
+++ b/src/provider/source/tuna-obs.ts
@@ -163,30 +163,20 @@ export class TunaObsProvider extends BaseSourceProvider {
       provider: 'tuna-obs',
     };
 
-    if (data.data.status === 'playing') {
-      result.data = {
-        type: 'playing',
-        id: `${data.data.title}:${data.data.cover_url}`,
-        title: data.data.title ?? '',
-        artists: data.data.artists ?? [],
-        progress: data.data.progress ?? 0,
-        duration: data.data.duration ?? 0,
-        coverUrl: data.data.cover_url ?? '',
-        playerLyrics: data.data.lyrics,
-        metadata: data,
-      };
-    }
+    if (data.data.status === 'playing' || data.data.status === 'paused') {
+      const lastLyric = this.lastUpdateData?.data.type !== 'idle'
+        ? this.lastUpdateData?.data.playerLyrics
+        : undefined;
 
-    if (data.data.status === 'paused') {
       result.data = {
-        type: 'paused',
+        type: data.data.status,
         id: `${data.data.title}:${data.data.cover_url}`,
         title: data.data.title ?? '',
         artists: data.data.artists ?? [],
         progress: data.data.progress ?? 0,
         duration: data.data.duration ?? 0,
         coverUrl: data.data.cover_url ?? '',
-        playerLyrics: data.data.lyrics,
+        playerLyrics: data.data.lyrics ?? lastLyric,
         metadata: data,
       };
     }


### PR DESCRIPTION
# Background
* The lyrics feature of the Spicetify extension does not work.
	* Internally, the Spotify has updated their endpoint of the lyrics service.

# Changes
* Update the API to match `color-lyrics/v2` API
* Fix TunaOBS to re-use existing lyrics.
	* As the Spicetify extension only sends lyrics once, to reduce overhead.